### PR TITLE
prevent double reorder

### DIFF
--- a/src/reducers/orderedReducer.js
+++ b/src/reducers/orderedReducer.js
@@ -58,13 +58,17 @@ function modifyDoc(collectionState, action) {
   // Support moving a doc within an array
   if (action.payload.ordered) {
     const { newIndex, oldIndex } = action.payload.ordered;
-    // newIndex/oldIndex values exist, item isn't being removed or added, and the index has changed
+
+    // newIndex/oldIndex values exist, item isn't being removed or added, the index has
+    // changed, and the update hasn't already been made in state
     if (
       newIndex !== null &&
       oldIndex !== null &&
       newIndex > -1 &&
       oldIndex > -1 &&
-      newIndex !== oldIndex
+      newIndex !== oldIndex &&
+      newIndex !==
+        collectionState.findIndex(document => document.id === action.meta.doc)
     ) {
       return newArrayWithItemMoved(
         collectionState,


### PR DESCRIPTION
This still needs to be looked at.

Changes come in from Firestore at random in all sorts of wacky ways. The current logic implemented to see if the reducer has fired for a change that's already occurred is buggy.